### PR TITLE
docs: clarify server options defaults

### DIFF
--- a/server/options.go
+++ b/server/options.go
@@ -19,13 +19,14 @@ type Options struct {
 	// Version is the runtime's advertised version.
 	Version string
 	// HeartbeatInterval seeds heartbeat_interval_sec in welcome. Zero
-	// disables heartbeats unless the client negotiates them; default
-	// is 30s.
+	// is replaced with the 30s default in withDefaults; omit the
+	// heartbeat feature if you need to suppress heartbeats entirely.
 	HeartbeatInterval time.Duration
 	// ResumeWindow seeds resume_window_sec; default 600s.
 	ResumeWindow time.Duration
-	// Verifier authenticates session.hello tokens. nil accepts no
-	// tokens.
+	// Verifier authenticates session.hello tokens. When nil, the
+	// runtime accepts the session and uses hello.Client.Name as the
+	// principal for anonymous/local mode.
 	Verifier auth.Verifier
 	// Logger is the slog.Logger used by the runtime. nil uses
 	// slog.Default().

--- a/server/options_test.go
+++ b/server/options_test.go
@@ -1,0 +1,20 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestOptionsWithDefaults(t *testing.T) {
+	opts := Options{}.withDefaults()
+
+	if got, want := opts.HeartbeatInterval, 30*time.Second; got != want {
+		t.Fatalf("HeartbeatInterval = %v, want %v", got, want)
+	}
+	if got, want := opts.ResumeWindow, 10*time.Minute; got != want {
+		t.Fatalf("ResumeWindow = %v, want %v", got, want)
+	}
+	if opts.Verifier != nil {
+		t.Fatalf("Verifier = %#v, want nil", opts.Verifier)
+	}
+}


### PR DESCRIPTION
Clarifies the Go server option comments to match implementation and adds a small test locking in the default heartbeat/resume/verifier behavior.