### PR TITLE
ci: upload coverage to Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,18 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
+      # Upload Go coverage profile from the `stable` matrix entry only.
+      # Non-blocking so a Codecov outage cannot break CI.
+      - name: Upload coverage to Codecov
+        if: matrix.go == 'stable'
+        # codecov/codecov-action v6.0.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          fail_ci_if_error: false
+          flags: unittests
+          files: ./coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Upload test output on failure
         if: failure() && hashFiles('test-output.txt') != ''
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Upload the existing `coverage.out` profile (produced on the `stable` matrix entry) to Codecov.
- `fail_ci_if_error: false` so a Codecov outage cannot break CI.

## Pre-merge action required
- Add `CODECOV_TOKEN` as a repo secret (`gh secret set CODECOV_TOKEN --repo agentruntimecontrolprotocol/go-sdk`).
- Activate the repo at [app.codecov.io](https://app.codecov.io/gh/agentruntimecontrolprotocol/go-sdk).

## Test plan
- [ ] Merge, confirm coverage uploads on next push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflow to improve code coverage tracking and reporting capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentruntimecontrolprotocol/go-sdk/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->